### PR TITLE
Add web interface server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Art Encoder/Decoder
 
-This is a command-line utility written in Go for encoding and decoding text files. The encoding format uses a simple scheme that repeats a line `STR` `N` times. In the `examples` directory you’ll find original and encoded ASCII-art files to try out the program.
+This project contains both a command line utility and a small web server for
+encoding and decoding text based art.  The encoding format uses a simple scheme
+that repeats a line `STR` `N` times.  In the `examples` directory you’ll find
+original and encoded ASCII-art files to try out the program.
 
 ## Installation
 
@@ -70,6 +73,23 @@ art/
     ├── encoder.go
     └── processing.go
 ```
+
+## Running the Web Interface
+
+The repository also includes a small HTTP server that hosts a web page for
+encoding and decoding art.
+
+```bash
+# build the server
+go build -o art-server server_main.go
+
+# or run it directly
+go run server_main.go
+```
+
+Navigate to `http://localhost:22459/` in your browser to use the interface. Use
+the radio buttons to switch between decoding and encoding modes and submit your
+text using the form.
 
 ## Contact
 

--- a/server_main.go
+++ b/server_main.go
@@ -1,0 +1,8 @@
+package main
+
+import "art/web"
+
+func main() {
+	server := &web.ArtServer{}
+	server.Run()
+}

--- a/styles/mainpage.css
+++ b/styles/mainpage.css
@@ -14,7 +14,6 @@ body {
 h1 {
     font-size: 2em;
     color: #8d44db;
-
 }
 
 .options {
@@ -31,60 +30,48 @@ h1 {
     align-items: center;
     gap: 1.5em;
     margin: 0.5em;
-    input[type="radio"] {
-        position: absolute;
-        opacity: 0;
-        + .radio-label {
-            &:before {
-                content: '';
-                background: #1b0c3b;
-                border-radius: 100%;
-                border: 1.5px solid #000000;
-                display: inline-block;
-                width: 1.4em;
-                height: 1.4em;
-                position: relative;
-                top: -0.2em;
-                margin-right: 1em;
-                vertical-align: top;
-                cursor: pointer;
-                text-align: center;
-                transition: all 250ms ease;
-            }
-        }
-        &:checked {
-            + .radio-label {
-                &:before {
-                    background: #33176d;
-                    box-shadow: inset 0 0 0 4px #2f1662;
-                }
-            }
-        }
-        &:focus {
-            + .radio-label {
-                &:before {
-                    outline: none;
-                    border-color: #090a30;
-                }
-            }
-        }
-        &:disabled {
-            + .radio-label {
-                &:before {
-                    box-shadow: inset 0 0 0 4px #3c2669;
-                    border-color: #ffffff;
-                    background: #090a30;
-                }
-            }
-        }
-        + .radio-label {
-            &:empty {
-                &:before {
-                    margin-right: 0;
-                }
-            }
-        }
-    }
+}
+
+.radio input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+}
+
+.radio input[type="radio"] + .radio-label::before {
+    content: '';
+    background: #1b0c3b;
+    border-radius: 100%;
+    border: 1.5px solid #000000;
+    display: inline-block;
+    width: 1.4em;
+    height: 1.4em;
+    position: relative;
+    top: -0.2em;
+    margin-right: 1em;
+    vertical-align: top;
+    cursor: pointer;
+    text-align: center;
+    transition: all 250ms ease;
+}
+
+.radio input[type="radio"]:checked + .radio-label::before {
+    background: #33176d;
+    box-shadow: inset 0 0 0 4px #2f1662;
+}
+
+.radio input[type="radio"]:focus + .radio-label::before {
+    outline: none;
+    border-color: #090a30;
+}
+
+.radio input[type="radio"]:disabled + .radio-label::before {
+    box-shadow: inset 0 0 0 4px #3c2669;
+    border-color: #ffffff;
+    background: #090a30;
+}
+
+.radio input[type="radio"] + .radio-label:empty::before {
+    margin-right: 0;
 }
 
 .art-areas {


### PR DESCRIPTION
## Summary
- implement HTTP server entry point
- fix status codes and error handling in web handlers
- convert CSS to valid syntax
- document how to run the web server

## Testing
- `go build -o art-cli main.go`
- `go build -o art-server server_main.go`


------
https://chatgpt.com/codex/tasks/task_e_685b172336c4832e9201d7f11dd496c5