### PR TITLE
Fix POST decoder to read plain text

### DIFF
--- a/web/outpoint.go
+++ b/web/outpoint.go
@@ -3,8 +3,10 @@ package web
 import (
 	"art/processing"
 	"html/template"
+	"io"
 	"log"
 	"net/http"
+	"strings"
 )
 
 func renderPage(w http.ResponseWriter, page *Page) {
@@ -38,18 +40,33 @@ func postDecoder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := r.ParseForm()
-	if err != nil {
-		http.Error(w, "Failed to parse form data", http.StatusBadRequest)
-		log.Printf("Error parsing form data: %s", err.Error())
-		return
+	contentType := r.Header.Get("Content-Type")
+
+	var input string
+	var setting string
+
+	if strings.HasPrefix(contentType, "text/plain") {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read request body", http.StatusBadRequest)
+			return
+		}
+		input = string(body)
+		setting = r.URL.Query().Get("setting")
+	} else {
+		err := r.ParseForm()
+		if err != nil {
+			http.Error(w, "Failed to parse form data", http.StatusBadRequest)
+			log.Printf("Error parsing form data: %s", err.Error())
+			return
+		}
+
+		input = r.FormValue("input_data")
+		setting = r.FormValue("setting")
 	}
 
-	log.Printf("Received setting %s", r.FormValue("setting"))
-	log.Printf("Received data:\n%s", r.FormValue("input_data"))
-
-	input := r.FormValue("input_data")
-	setting := r.FormValue("setting")
+	log.Printf("Received setting %s", setting)
+	log.Printf("Received data:\n%s", input)
 
 	encode := false
 	if setting == "encode" {


### PR DESCRIPTION
## Summary
- support text/plain requests in the `/decoder` endpoint
- return HTTP 400 when the decoder receives invalid content

## Testing
- `go build ./server_main.go`


------
https://chatgpt.com/codex/tasks/task_e_685f04d62ce0832eb72d4234a02f48ab